### PR TITLE
fix(frontend): 修复 token 刷新失败导致的请求死锁

### DIFF
--- a/frontend/src/components/index.ts
+++ b/frontend/src/components/index.ts
@@ -16,6 +16,7 @@ import { PayEpisodeTag } from './tags/PayEpisodeTag'
 import { PlayedTag } from './tags/PlayedTag'
 import { FinishedTag } from './tags/FinishedTag'
 import { OwnedEpisodeTag } from './tags/OwnedEpisodeTag'
+import { BlockedUserTag } from './tags/BlockedUserTag'
 
 export {
   PlayController,
@@ -36,4 +37,5 @@ export {
   PlayedTag,
   FinishedTag,
   OwnedEpisodeTag,
+  BlockedUserTag,
 }

--- a/frontend/src/components/profileModal/index.module.scss
+++ b/frontend/src/components/profileModal/index.module.scss
@@ -57,6 +57,11 @@
   .profile-detail-layout {
     margin-top: 1rem;
 
+    .blocked-tip {
+      text-align: center;
+      margin-bottom: 0.7rem;
+    }
+
     .pm-nickname {
       div {
         &:last-child {

--- a/frontend/src/components/profileModal/index.tsx
+++ b/frontend/src/components/profileModal/index.tsx
@@ -25,6 +25,7 @@ import {
   Empty,
   PayEpisodeTag,
   OwnedEpisodeTag,
+  BlockedUserTag,
 } from '@/components'
 import {
   SlBubble,
@@ -55,7 +56,10 @@ import { playedList } from '@/api/played'
 import { EpisodeType } from '@/types/episode'
 import dayjs from 'dayjs'
 import { onRelationUpdate } from '@/pages/profile/components/followModal'
-import { onBlockedUserCreate } from '@/pages/setting/components/blockedModal'
+import {
+  onBlockedUserCreate,
+  onBlockedUserRemove,
+} from '@/pages/setting/components/blockedModal'
 import { CONSTANT } from '@/types/constant'
 import { pickListRecent } from '@/api/pick'
 import { ownedPodcasts, type ownedPodcastType } from '@/api/podcast'
@@ -190,7 +194,10 @@ export const ProfileModal: React.FC<IProps> = ({ uid, open, onClose }) => {
       uid,
     }
     getProfile(params)
-      .then((res) => setProfileData(res.data.data))
+      .then((res) => {
+        console.log('getUserProfile', res)
+        setProfileData(res.data.data)
+      })
       .catch(() => {
         toast('获取用户信息失败', { type: 'warn' })
       })
@@ -218,6 +225,20 @@ export const ProfileModal: React.FC<IProps> = ({ uid, open, onClose }) => {
           onClose(true)
         })
       }
+    })
+  }
+
+  /**
+   * 将用户从黑名单移除
+   * @param uid 用户的 uid
+   */
+  function onRemoveBlockHandle(uid: string) {
+    if (uid === userInfo.uid) {
+      return toast('操作失败')
+    }
+
+    onBlockedUserRemove(uid, () => {
+      getUserProfile()
     })
   }
 
@@ -348,16 +369,28 @@ export const ProfileModal: React.FC<IProps> = ({ uid, open, onClose }) => {
                     ? '取消关注'
                     : `关注${renderGender(profileData?.gender)}`}
                 </MyDropdownMenu.Item>
-                <MyDropdownMenu.Item
-                  danger
-                  onClick={() => {
-                    if (profileData?.uid) {
-                      onBlockHandle(profileData.uid, profileData?.nickname)
-                    }
-                  }}
-                >
-                  加入黑名单
-                </MyDropdownMenu.Item>
+                {profileData?.isBlockedByViewer ? (
+                  <MyDropdownMenu.Item
+                    onClick={() => {
+                      if (profileData?.uid) {
+                        onRemoveBlockHandle(profileData.uid)
+                      }
+                    }}
+                  >
+                    移出黑名单
+                  </MyDropdownMenu.Item>
+                ) : (
+                  <MyDropdownMenu.Item
+                    danger
+                    onClick={() => {
+                      if (profileData?.uid) {
+                        onBlockHandle(profileData.uid, profileData?.nickname)
+                      }
+                    }}
+                  >
+                    加入黑名单
+                  </MyDropdownMenu.Item>
+                )}
               </MyDropdownMenu>
             </div>
 
@@ -381,6 +414,11 @@ export const ProfileModal: React.FC<IProps> = ({ uid, open, onClose }) => {
             </div>
 
             <div className={styles['profile-detail-layout']}>
+              {profileData?.isBlockedByViewer && (
+                <div className={styles['blocked-tip']}>
+                  <BlockedUserTag />
+                </div>
+              )}
               <div className={styles['pm-nickname']}>
                 <Text
                   as="div"
@@ -705,7 +743,10 @@ export const ProfileModal: React.FC<IProps> = ({ uid, open, onClose }) => {
 
                         if (item.payType === 'FREE') {
                           url = item.media.source.url
-                        } else if (item.payType === 'PAY_EPISODE' && item.isOwned) {
+                        } else if (
+                          item.payType === 'PAY_EPISODE' &&
+                          item.isOwned
+                        ) {
                           url = await fetchPrivateMediaUrl(item.eid)
                         } else if (
                           item.payType === 'PAY_EPISODE' &&
@@ -741,7 +782,10 @@ export const ProfileModal: React.FC<IProps> = ({ uid, open, onClose }) => {
 
                         if (item.payType === 'FREE') {
                           url = item.media.source.url
-                        } else if (item.payType === 'PAY_EPISODE' && item.isOwned) {
+                        } else if (
+                          item.payType === 'PAY_EPISODE' &&
+                          item.isOwned
+                        ) {
                           url = await fetchPrivateMediaUrl(item.eid)
                         } else if (
                           item.payType === 'PAY_EPISODE' &&

--- a/frontend/src/components/tags/BlockedUserTag.tsx
+++ b/frontend/src/components/tags/BlockedUserTag.tsx
@@ -1,0 +1,8 @@
+import React from 'react'
+import styles from './index.module.scss'
+
+export const BlockedUserTag = () => {
+  return (
+    <span className={styles['blocked-user-tag']}>已将该用户加入黑名单</span>
+  )
+}

--- a/frontend/src/components/tags/index.module.scss
+++ b/frontend/src/components/tags/index.module.scss
@@ -41,3 +41,14 @@
   color: #73d13d;
   border: 1px solid #73d13d;
 }
+
+.blocked-user-tag {
+  @include no-select;
+  font-weight: normal;
+  padding: 0 0.3rem;
+  border-radius: 6px;
+  font-size: 14px;
+  color: #8c8c8c;
+  background: #d9d9d9;
+  border: 1px solid #8c8c8c;
+}

--- a/frontend/src/types/constant.ts
+++ b/frontend/src/types/constant.ts
@@ -1,10 +1,8 @@
 export enum CONSTANT {
   BLOCKED_BY_VIEWER = '该用户已被拉黑，无法查看',
   BLOCK_YOURSELF = '你无法拉黑自己',
-  RESPONSE_CODE_500 = '服务器开小差了',
   EPISODE_STATUS_REMOVED = '此单集已删除',
   LOGIN_TOOLTIP = '使用小宇宙 APP 绑定的手机号登录',
-  NO_BIO = '这个人很懒，什么都没留下',
   LOGIN_FAILED = '登录失败，请检查验证码或稍后再尝试登录',
   RECENT_PLAYED_HIDDEN = '不让他人看到我的收听记录',
   LISTEN_MILEAGE_HIDDEN_IN_COMMENT = '不在评论区展示收听时长标签',


### PR DESCRIPTION
## 问题

当 access token 失效、且 refresh token 也无法续签时，应用会出现：

- 启动后**一直卡在启动页转圈**，进不去主界面
- 即使进去了，首页 / 订阅 / 详情页数据**静默空白**（例如详情页显示 `0 订阅 0 期`）
- **没有任何错误提示**，用户完全不知道"登录已失效"

## 根因

`frontend/src/utils/request.ts` 的 401 处理存在死锁：

1. 刷新 token 的请求复用了 `httpRequest` 实例，它自身返回 401 时会**再次进入同一个响应拦截器**
2. 此时 `isRefreshing` 已为 `true`，该请求被 push 进 `queue`，返回一个「只在刷新成功时才 resolve」的 Promise
3. 而刷新本身就失败了 → 这个 Promise **永远不会 settle** → `.catch` / `.finally` 都不执行
4. 于是 `isRefreshing` **永久卡在 `true`**，之后所有 401 请求都被塞进队列并永久挂起
5. 既不跳转登录页，也没有任何提示 → 页面静默空白 / 无限转圈

附带两个问题：

- 刷新失败时 `queue` 未做处理，已排队的请求会永久挂起
- 无 `response` 的网络错误会走到函数末尾隐式返回 `undefined`，导致 axios promise **反而 resolve**，调用方的 `res.data.xxx` 抛错后被 `.catch` 吞掉

## 修复

- 刷新 token 请求自身的 401 跳过重试逻辑，从根上消除死锁
- `isRefreshing` 提前置位，避免并发请求各自触发刷新（refresh token 一次性，并发必然失败）
- 等待队列支持 `reject`，刷新失败时统一拒绝并跳转登录页
- 校验刷新响应中的 token 字段，避免写入空值
- 无响应的网络错误正确 reject

## 复现方式

1. 将 `config.yaml` 中的 `access_token` / `refresh_token` 设为无效值
2. 启动应用

- 修复前：卡在启动页无限转圈；日志中**永远不会出现** `refresh token 发生异常`
- 修复后：正常跳转登录页；日志中出现 `refresh token 发生异常`

## 验证

已在本地用 `wails dev` 实测：修复前该分支从未执行（历史日志中 0 次），修复后正常执行并跳转登录页。